### PR TITLE
Match test name to test body

### DIFF
--- a/__tests__/MMM-Chore-Manager.spec.js
+++ b/__tests__/MMM-Chore-Manager.spec.js
@@ -16,7 +16,7 @@ describe('MMM-Chore-Manager', () => {
     MMMChoreManager.setData({ name, identifier: `Module_1_${name}` });
   });
 
-  test('requires version 2.1', () => {
+  test('requires version 2.2.0', () => {
     expect(MMMChoreManager.requiresVersion).toBe('2.2.0');
   });
 


### PR DESCRIPTION
It might make sense to name it "requires expected version" or something else more abstract. ¯\\\_(ツ)_/¯